### PR TITLE
Add support for void Result.success() and refine type checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.0] - 2024-11-01
-### 🔒 Improvements
-- **Enhanced** the `Result` type by adding `extends NonNullable<unknown>` to prevent the use of `null` or `undefined` as possible result types.
+### **How to Use This Changelog**
+This changelog documents all releases and notable changes. Use this to understand what’s new, improved, or fixed in each version.
+
+---
+
+## [1.1.0] - 2024-12-15
+
+### ✨ New Features
+- **Added** support for using `Result.success()` without a value, specifically as `Result.success<void>()`, to represent successful operations with no result.
+
+#### Example
+
+```typescript
+const result = Result.success(); // ✅ Represents a success with no value.
+const voidResult = Result.success<void>(); // ✅ Explicitly denotes a success with void type.
+```
+
+#### Notes
+
+- **Previously** - the only way to create a `Result.success<void>` was using `Result.success<void>(undefined)`.
 
 ---
 
@@ -20,8 +37,3 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **Implemented** `fold` method to handle both success and failure cases in one function.
 - **Provided** utility methods like `onSuccess` and `onFailure` for executing actions based on the result type.
 - **Added** `toString` method to convert the `Result` object to a string representation for easy logging and debugging.
-
----
-
-### **How to Use This Changelog**
-This changelog documents all releases and notable changes. Use this to understand what’s new, improved, or fixed in each version.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ A discriminated union that encapsulates a successful outcome with a value of typ
 
 - #### success
 
-`success(value: Value)`
+`static success(value: Value)`
 
 Returns an instance that encapsulates the given value as successful value.
 
@@ -78,7 +78,7 @@ const result = Result.success('action succeeded');
 
 - #### failure
 
-`failure(error: Error)`
+`static failure(error: Error)`
 
 Returns an instance that encapsulates the given error as failure.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@felipearpa/resulting",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@felipearpa/resulting",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "ISC",
       "devDependencies": {
         "@jest/globals": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felipearpa/resulting",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Result type based on Kotlin Result type",
   "repository": {
     "type": "git",
@@ -29,7 +29,10 @@
   },
   "keywords": [
     "felipearpa",
-    "result"
+    "result",
+    "success",
+    "failure",
+    "try-catch"
   ],
   "author": "Felipe Arcila Parra",
   "license": "ISC",

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -358,4 +358,74 @@ describe('Result', () => {
             thenTheErrorRepresentationStringIsRetrieved(retrievedRepresentationString);
         });
     });
+
+    describe('Result<void>', () => {
+        const voidSuccessResult = Result.success();
+        const voidFailureResult = Result.failure<void>(error);
+
+        test('given a void success result when retrieving the value safely then the value is retrieved', () => {
+            const unsafeWhenGetOrThrowIsExecuted = () => {
+                voidSuccessResult.getOrThrow();
+            };
+
+            expect(unsafeWhenGetOrThrowIsExecuted).not.toThrow(Error);
+        });
+
+        test('given a void error result when retrieving the value safely then the error is raised', () => {
+            const unsafeWhenGetOrThrowIsExecuted = () => {
+                voidFailureResult.getOrThrow();
+            };
+
+            expect(unsafeWhenGetOrThrowIsExecuted).toThrow(Error);
+        });
+    });
+
+    describe('Result.success type safety', () => {
+        test('given an implicit void success result when instantiated without annotation then is allowed', () => {
+            const result = Result.success();
+            expect(result).toBeInstanceOf(Result<void>);
+        });
+
+        test('given an explicit void success result when instantiated without annotation then is allowed', () => {
+            const result: Result<void> = Result.success();
+            expect(result).toBeInstanceOf(Result<void>);
+        });
+
+        test('given an implicit void success result when instantiated with annotation then is allowed', () => {
+            const result = Result.success<void>();
+            expect(result).toBeInstanceOf(Result<void>);
+        });
+
+        test('given an explicit void success result when instantiated with annotation then is allowed', () => {
+            const result: Result<void> = Result.success<void>();
+            expect(result).toBeInstanceOf(Result<void>);
+        });
+
+        test('given an implicit void success result when is instanced with annotation and undefined as parameter then is allowed', () => {
+            const result = Result.success<void>(undefined);
+            expect(result).toBeInstanceOf(Result<void>);
+        });
+
+        test('given an explicit void success result when is instanced with annotation and undefined as parameter then is allowed', () => {
+            const result: Result<void> = Result.success<void>(undefined);
+            expect(result).toBeInstanceOf(Result<void>);
+        });
+
+        test('given an undefined success result when is instanced then is allowed', () => {
+            const result = Result.success<undefined>();
+            expect(result).toBeInstanceOf(Result<undefined>);
+        });
+
+        test('given a string success result when is instanced then is allowed', () => {
+            const result = Result.success('hello');
+            expect(result).toBeInstanceOf(Result<string>);
+            expect(result.getOrNull()).toBe('hello');
+        });
+
+        test('given a number success result when is instanced then is allowed', () => {
+            const result = Result.success(42);
+            expect(result).toBeInstanceOf(Result<number>);
+            expect(result.getOrNull()).toBe(42);
+        });
+    });
 });

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,4 +1,4 @@
-class SuccessType<Value extends NonNullable<unknown>> {
+class SuccessType<Value> {
     readonly type = 'success';
 
     constructor(public readonly value: Value) {}
@@ -10,12 +10,12 @@ class FailureType {
     constructor(public readonly error: Error) {}
 }
 
-type ResultType<Value extends NonNullable<unknown>> = SuccessType<Value> | FailureType;
+type ResultType<Value> = SuccessType<Value> | FailureType;
 
 /**
  * A discriminated union that encapsulates a successful outcome with a value of type Value or a failure with an arbitrary error.
  */
-export class Result<Value extends NonNullable<unknown>> {
+export class Result<Value> {
     /**
      * Returns true if this instance represents a successful outcome. In this case isFailure returns false.
      *
@@ -48,13 +48,24 @@ export class Result<Value extends NonNullable<unknown>> {
     private constructor(private readonly result: ResultType<Value>) {}
 
     /**
-     * Returns an instance that encapsulates the given value as successful value.
+     * Returns an instance that encapsulates a successful value.
+     *
+     * @return {Result<void>} The instance that encapsulates a successful value.
+     */
+    static success<Value extends void>(): Result<Value>;
+
+    /**
+     * Returns an instance that encapsulates the given value as a successful value.
      *
      * @template Value
      * @param {Value} value - The value representing a successful outcome.
-     * @returns {Result<Value>} The instance that encapsulates the given value as successful value.
+     * @returns {Result<Value>} The instance that encapsulates the given value as a successful value.
      */
-    static success = <Value extends NonNullable<unknown>>(value: Value): Result<Value> => new Result<Value>(new SuccessType(value));
+    static success<Value>(value: Value): Result<Value>;
+
+    static success<Value>(value?: Value extends void ? never : Value): Result<Value> {
+        return new Result<Value>(new SuccessType(value as Value));
+    }
 
     /**
      * Returns an instance that encapsulates the given error as failure.
@@ -63,7 +74,7 @@ export class Result<Value extends NonNullable<unknown>> {
      * @param {Error} error - The error representing a failure outcome.
      * @returns {Result<Value>} The instance that encapsulates the given error as failure.
      */
-    static failure = <Value extends NonNullable<unknown>>(error: Error): Result<Value> => new Result<Value>(new FailureType(error));
+    static failure = <Value>(error: Error): Result<Value> => new Result<Value>(new FailureType(error));
 
     /**
      * Returns the encapsulated value if this instance represents success or null if it is failure.
@@ -113,7 +124,7 @@ export class Result<Value extends NonNullable<unknown>> {
      * @return {NewValue} The encapsulated value if this instance represents success or the result of onFailure function for the encapsulated Error if it is
      * failure.
      */
-    getOrElse<NewValue, Value extends NonNullable<unknown> & NewValue>(this: Result<Value>, onFailure: (error: Error) => NewValue): NewValue {
+    getOrElse<NewValue, Value extends NewValue>(this: Result<Value>, onFailure: (error: Error) => NewValue): NewValue {
         const error = this.errorOrNull();
         if (error == null) {
             return this.value as Value;
@@ -141,7 +152,7 @@ export class Result<Value extends NonNullable<unknown>> {
      * @return {Result<NewValue>} The encapsulated result of the given transform function applied to the encapsulated value if this instance represents success
      * or the original encapsulated error if it is failure.
      */
-    map<NewValue extends NonNullable<unknown>>(transform: (value: Value) => NewValue): Result<NewValue> {
+    map<NewValue>(transform: (value: Value) => NewValue): Result<NewValue> {
         if (this.isSuccess) return Result.success(transform(this.value as Value));
         return Result.failure(this.value as Error);
     }
@@ -172,7 +183,7 @@ export class Result<Value extends NonNullable<unknown>> {
      * @return {Result<NewValue>} The encapsulated result of the given transform function applied to the encapsulated error if this instance represents
      * failure or the original encapsulated value if it is success.
      */
-    recover<NewValue extends NonNullable<unknown>, Value extends NewValue>(this: Result<Value>, transform: (error: Error) => NewValue): Result<NewValue> {
+    recover<NewValue, Value extends NewValue>(this: Result<Value>, transform: (error: Error) => NewValue): Result<NewValue> {
         const error = this.errorOrNull();
         if (error == null) {
             return this;


### PR DESCRIPTION
Introduce the ability to use `Result.success()` without a value, enabling the representation of successful operations with no result. Refined type constraints to improve flexibility and usability across the library.