### PR TITLE
Add support for object parameter in `fold` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ This changelog documents all releases and notable changes. Use this to understan
 
 ---
 
+## [1.2.0] - 2025-01-06
+
+### ✨ New Features
+
+- **Added support for object parameter in the `fold` method:**
+  The `fold` method now accepts an object with `onSuccess` and `onFailure` handlers as an alternative to the traditional positional parameters. This provides more flexibility and improves code readability when handling both success and failure cases.
+  **Example:**
+
+```typescript
+const result: Result<number> = Result.success(42);
+
+const transformedResult = result.fold({
+    onSuccess: (value) => `Success! The value is ${value}`,
+    onFailure: (error) => `Failure! The error is: ${error.message}`,
+});
+
+console.log(transformedResult); // Output: Success! The value is 42
+```
+
+---
+
 ## [1.1.0] - 2024-12-15
 
 ### ✨ New Features

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Resulting
 
-The **Resulting** package provides a `Result` class designed to handle success and failure scenarios in a functional programming style. It encapsulates a result,
+The **Resulting** package provides a `Result` class designed to handle success and failure scenarios in a functional programming style. It encapsulates a
+result,
 which can either be a `Success` with a value or a `Failure` with an error, offering methods to safely operate on these results. This type is based on
 the `Kotlin` `Result` type.
 
@@ -50,7 +51,8 @@ If you would like to contribute, please open a pull request or submit an issue. 
 
 ## License
 
-This project is licensed under the [MIT License](LICENSE). You are free to use, modify, and distribute this software for both personal and commercial use. There are no
+This project is licensed under the [MIT License](LICENSE). You are free to use, modify, and distribute this software for both personal and commercial use. There
+are no
 restrictions on usage.
 
 You can now add this section to your README.md to reflect that the project is open source and free to use. Let me know if you’d like to include additional
@@ -253,6 +255,8 @@ if (transformedResult.isSuccess) {
 
 `fold<NewValue>(onSuccess: (value: Value) => NewValue, onFailure: (error: Error) => NewValue): NewValue`
 
+`fold<NewValue>(handlers: { onSuccess: (value: Value) => NewValue, onFailure: (error: Error) => NewValue }): NewValue`
+
 Returns the result of onSuccess for the encapsulated value if this instance represents success or the result of onFailure function for the encapsulated error
 if it is failure.
 
@@ -272,12 +276,38 @@ console.log(transformedResult); // Output: Success! The value is: 42
 ```typescript
 import { Result } from '@felipearpa/resulting';
 
+const result: Result<number> = Result.success(42);
+
+const transformedResult = result.fold({
+    onSuccess: (value) => `Success! The value is ${value}`,
+    onFailure: (error) => `Failure! The error is: ${error.message}`
+});
+
+console.log(transformedResult); // Output: Success! The value is: 42
+```
+
+```typescript
+import { Result } from '@felipearpa/resulting';
+
 const result: Result<number> = Result.failure(Error('action failed'));
 
 const transformedResult = result.fold(
     value => `Success! The value is ${value}`,
     error => `Failure! The error is: ${error.message}`
 );
+
+console.log(transformedResult); // Output: Failure! The error is: action failed
+```
+
+```typescript
+import { Result } from '@felipearpa/resulting';
+
+const result: Result<number> = Result.failure(Error('action failed'));
+
+const transformedResult = result.fold({
+    onSuccess: (value) => `Success! The value is ${value}`,
+    onFailure: (error) => `Failure! The error is: ${error.message}`
+});
 
 console.log(transformedResult); // Output: Failure! The error is: action failed
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@felipearpa/resulting",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@felipearpa/resulting",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "ISC",
       "devDependencies": {
         "@jest/globals": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felipearpa/resulting",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Result type based on Kotlin Result type",
   "repository": {
     "type": "git",

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -213,10 +213,6 @@ describe('Result', () => {
     });
 
     describe('fold', () => {
-        const whenFolding = (result: Result<string>, onSuccess: (value: string) => string, onFailure: (error: Error) => string) => {
-            return result.fold(onSuccess, onFailure);
-        };
-
         const thenTheSuccessTransformationIsApplied = (retrievedValue: string) => {
             expect(successTransform).toBeCalled();
             expect(failureTransform).not.toBeCalled();
@@ -229,16 +225,40 @@ describe('Result', () => {
             expect(retrievedValue).toBe(failureTransform(error));
         };
 
-        test('given a success result when folding then the success transformation is applied', () => {
-            const successResult = givenASuccessResult();
-            const retrievedValue = whenFolding(successResult, successTransform, failureTransform);
-            thenTheSuccessTransformationIsApplied(retrievedValue);
+        describe('fold by using individual handlers', () => {
+            const whenFolding = (result: Result<string>, onSuccess: (value: string) => string, onFailure: (error: Error) => string) => {
+                return result.fold(onSuccess, onFailure);
+            };
+
+            test('given a success result when folding then the success transformation is applied', () => {
+                const successResult = givenASuccessResult();
+                const retrievedValue = whenFolding(successResult, successTransform, failureTransform);
+                thenTheSuccessTransformationIsApplied(retrievedValue);
+            });
+
+            test('given a failure result when folding then the transformation for failure is applied', () => {
+                const successResult = givenAFailureResult();
+                const retrievedValue = whenFolding(successResult, successTransform, failureTransform);
+                thenTheFailureTransformationIsNotApplied(retrievedValue);
+            });
         });
 
-        test('given a failure result when folding then the transformation for failure is applied', () => {
-            const successResult = givenAFailureResult();
-            const retrievedValue = whenFolding(successResult, successTransform, failureTransform);
-            thenTheFailureTransformationIsNotApplied(retrievedValue);
+        describe('fold by using an object', () => {
+            const whenFolding = (result: Result<string>, transformation: { onSuccess: (value: string) => string; onFailure: (error: Error) => string }) => {
+                return result.fold(transformation);
+            };
+
+            test('given a success result when folding then the success transformation is applied', () => {
+                const successResult = givenASuccessResult();
+                const retrievedValue = whenFolding(successResult, { onSuccess: successTransform, onFailure: failureTransform });
+                thenTheSuccessTransformationIsApplied(retrievedValue);
+            });
+
+            test('given a failure result when folding then the transformation for failure is applied', () => {
+                const successResult = givenAFailureResult();
+                const retrievedValue = whenFolding(successResult, { onSuccess: successTransform, onFailure: failureTransform });
+                thenTheFailureTransformationIsNotApplied(retrievedValue);
+            });
         });
     });
 

--- a/src/result.ts
+++ b/src/result.ts
@@ -168,10 +168,37 @@ export class Result<Value> {
      * @return {NewValue} The result of onSuccess for the encapsulated value if this instance represents success or the result of onFailure function for the
      * encapsulated error if it is failure.
      */
-    fold<NewValue>(onSuccess: (value: Value) => NewValue, onFailure: (error: Error) => NewValue): NewValue {
-        const error = this.errorOrNull();
-        if (error == null) return onSuccess(this.value as Value);
-        return onFailure(error);
+    fold<NewValue>(onSuccess: (value: Value) => NewValue, onFailure: (error: Error) => NewValue): NewValue;
+
+    /**
+     * Returns the result of onSuccess for the encapsulated value if this instance represents success or the result of onFailure function for the encapsulated
+     * error if it is failure.
+     *
+     * @template Value
+     * @template NewValue
+     * @param {Object} handlers - An object containing the functions to handle success and failure states.
+     * @param {(Value) => NewValue} handlers.onSuccess - Function to process the successful value.
+     * @param {(Error) => NewValue} handlers.onFailure - Function to process the error value.
+     * @return {NewValue} The result of the executed handler function.
+     */
+    fold<NewValue>(handlers: { onSuccess: (value: Value) => NewValue; onFailure: (error: Error) => NewValue }): NewValue;
+
+    fold<NewValue>(
+        handlers:
+            | {
+                  onSuccess: (value: Value) => NewValue;
+                  onFailure: (error: Error) => NewValue;
+              }
+            | ((value: Value) => NewValue),
+        onFailure?: (error: Error) => NewValue,
+    ): NewValue {
+        if (typeof handlers === 'object') {
+            const { onSuccess, onFailure } = handlers;
+            return this.fold(onSuccess, onFailure);
+        }
+
+        if (this.isSuccess) return (handlers as (value: Value) => NewValue)((this.result as { value: Value }).value);
+        return (onFailure as (error: Error) => NewValue)((this.result as { error: Error }).error);
     }
 
     /**


### PR DESCRIPTION
The `fold` method now accepts an object with `onSuccess` and `onFailure` handlers, improving clarity and flexibility when handling result states. Updated tests, documentation, and examples to reflect and validate this enhancement.