### PR TITLE
Feature/type guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ This changelog documents all releases and notable changes. Use this to understan
 
 ---
 
+## [1.3.0] - 2025-06-22
+
+### ✨ New Features
+
+- **Added type guard functions `isSuccessResult` and `isFailureResult`:**
+  These new functions allow for precise type narrowing when working with `Result` objects, enabling safer access to the underlying `value` or `error` in `Success` and `Failure` instances, respectively.
+  **Example:**
+  ```typescript
+  if (isSuccessResult(result)) {
+      console.log(result.value); // Safe to access
+  }
+
+  if (isFailureResult(result)) {
+      console.error(result.error); // Safe to access
+  }
+  ```
+
+---
+
 ## [1.2.0] - 2025-01-06
 
 ### ✨ New Features

--- a/README.md
+++ b/README.md
@@ -566,3 +566,33 @@ if (result.isSuccess) {
     console.error('Failure:', result.errorOrNull()?.message); // If failure, log the error
 }
 ```
+
+### isSuccessResult
+
+`const isSuccessResult = <Value>(result: Result<Value>): result is Success<Value> => result instanceof Success`
+
+A type guard function that checks if the given result is an instance of the Success class.
+
+```typescript
+import { Result, isSuccessResult } from '@felipearpa/resulting';
+
+const result = Result.success('value');
+if (isSuccessResult(result)) {
+    console.log(result.value); // Output: value
+}
+```
+
+### isFailureResult
+
+`const isFailureResult = <Value>(result: Result<Value>): result is Failure<Value> => result instanceof Failure`
+
+A type guard function that checks whether a `Result` object is a failure instance.
+
+```typescript
+import { Result, isFailureResult } from '@felipearpa/resulting';
+
+const result = Result.failure(Error('error'));
+if (isFailureResult(result)) {
+    console.log(result.error.message); // Output: error
+}
+```

--- a/README.md
+++ b/README.md
@@ -88,15 +88,21 @@ yarn install @felipearpa/resulting
 Here’s how you can use the package after installation. You can import the package and use its features like this:
 
 ```typescript
-import { Result } from '@felipearpa/resulting';
+import { Result, isSuccessResult, isFailureResult } from '@felipearpa/resulting';
 
-const successFailure = Result.success('success result');
+const successResult = Result.success('success result');
 console.log(successResult.isSuccess); // Output: true
 console.log(successResult.isFailure); // Output: false
+if (isSuccessResult(successResult)) {
+    console.log(successResult.value); // Output: success result
+}
 
 const failureResult = Result.failure(Error('error result'));
 console.log(failureResult.isFailure); // Output: true
 console.log(failureResult.isSuccess); // Output: false
+if (isFailureResult(failureResult)) {
+    console.log(failureResult.error); // Output: error result
+}
 ```
 
 ## Running Tests

--- a/src/result-catching.extension.ts
+++ b/src/result-catching.extension.ts
@@ -30,9 +30,9 @@ declare module './result' {
 
 Result.prototype.mapCatching = function (transform) {
     if (this.isSuccess) {
-        return runCatching(() => transform(this.value));
+        return runCatching(() => transform(this.rawValue));
     }
-    return Result.failure(this.value as Error);
+    return Result.failure(this.rawValue as Error);
 };
 
 Result.prototype.recoverCatching = function <NewValue extends NonNullable<unknown>, Value extends NewValue>(

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -1,4 +1,4 @@
-import { Result } from './result';
+import { isFailureResult, isSuccessResult, Result } from './result';
 import { beforeEach, describe, expect, jest, test } from '@jest/globals';
 
 describe('Result', () => {
@@ -244,19 +244,31 @@ describe('Result', () => {
         });
 
         describe('fold by using an object', () => {
-            const whenFolding = (result: Result<string>, transformation: { onSuccess: (value: string) => string; onFailure: (error: Error) => string }) => {
+            const whenFolding = (
+                result: Result<string>,
+                transformation: {
+                    onSuccess: (value: string) => string;
+                    onFailure: (error: Error) => string;
+                },
+            ) => {
                 return result.fold(transformation);
             };
 
             test('given a success result when folding then the success transformation is applied', () => {
                 const successResult = givenASuccessResult();
-                const retrievedValue = whenFolding(successResult, { onSuccess: successTransform, onFailure: failureTransform });
+                const retrievedValue = whenFolding(successResult, {
+                    onSuccess: successTransform,
+                    onFailure: failureTransform,
+                });
                 thenTheSuccessTransformationIsApplied(retrievedValue);
             });
 
             test('given a failure result when folding then the transformation for failure is applied', () => {
                 const successResult = givenAFailureResult();
-                const retrievedValue = whenFolding(successResult, { onSuccess: successTransform, onFailure: failureTransform });
+                const retrievedValue = whenFolding(successResult, {
+                    onSuccess: successTransform,
+                    onFailure: failureTransform,
+                });
                 thenTheFailureTransformationIsNotApplied(retrievedValue);
             });
         });
@@ -446,6 +458,28 @@ describe('Result', () => {
             const result = Result.success(42);
             expect(result).toBeInstanceOf(Result<number>);
             expect(result.getOrNull()).toBe(42);
+        });
+    });
+
+    describe('type guard for Result', () => {
+        test('given a success result when checking type guard then SuccessResult is retrieved', () => {
+            const result = Result.success('test-value');
+
+            if (isSuccessResult(result)) {
+                expect(result.value).toBe('test-value');
+            } else {
+                throw new Error('Expected result to be a success');
+            }
+        });
+
+        test('given a failure result when checking type guard then FailureResult is retrieved', () => {
+            const result = Result.failure(Error());
+
+            if (isFailureResult(result)) {
+                expect(result.error).toBeInstanceOf(Error);
+            } else {
+                throw new Error('Expected result to be a failure');
+            }
         });
     });
 });


### PR DESCRIPTION
Add `isSuccessResult` and `isFailureResult` functions to enable type-safe narrowing of Result instances