### PR TITLE
Relax generic constraints and fix result state evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This changelog documents all releases and notable changes. Use this to understan
 
 ---
 
-## [1.3.0] - 2025-06-22
+## [1.3.0] - 2025-06-23
 
 
 ### ✨ New Features
@@ -43,6 +43,14 @@ This changelog documents all releases and notable changes. Use this to understan
   }
   ```
 
+### 🐞 Bug Fixes
+
+- **Relaxed generic constraint for transformation types:**
+  Fixed overly strict generic constraints such as `NewValue extends NonNullable<unknown>` which unnecessarily restricted valid types like `null` or `undefined`. The constraint has been removed to allow broader usage in `map`, `mapCatching`, and related transformation methods.
+
+- **Fixed internal usage of `errorOrNull()` for state detection:**
+  Previously, some internal methods used `errorOrNull()` to determine whether a `Result` represented failure or success, which could lead to incorrect behavior when the success `Value` was `null`. These usages have been replaced with `isSuccess` and `isFailure` checks to ensure accurate and type-safe result evaluation.
+
 ---
 
 ## [1.2.0] - 2025-01-06
@@ -74,8 +82,8 @@ console.log(transformedResult); // Output: Success! The value is 42
 #### Example
 
 ```typescript
-const result = Result.success(); // ✅ Represents a success with no value.
-const voidResult = Result.success<void>(); // ✅ Explicitly denotes a success with void type.
+const result = Result.success(); // Represents a success with no value.
+const voidResult = Result.success<void>(); // Explicitly denotes a success with void type.
 ```
 
 #### Notes

--- a/src/result-catching.extension.ts
+++ b/src/result-catching.extension.ts
@@ -13,7 +13,7 @@ declare module './result' {
          * @return {Result<NewValue, Error>} The encapsulated result of the given transform function applied to the encapsulated value if this instance represents
          * success or the original encapsulated error if it is failure.
          */
-        mapCatching<NewValue extends NonNullable<unknown>>(transform: (value: Value) => NewValue): Result<NewValue, Error>;
+        mapCatching<NewValue>(transform: (value: Value) => NewValue): Result<NewValue, Error>;
 
         /**
          * Returns the encapsulated result of the given transform function applied to the encapsulated error if this instance represents failure or the original
@@ -24,7 +24,7 @@ declare module './result' {
          * @return {Result<NewValue, Error>} The encapsulated result of the given transform function applied to the encapsulated error if this instance represents
          * failure or the original encapsulated value if it is success.
          */
-        recoverCatching<NewValue extends NonNullable<unknown>>(transform: (error: Error) => NewValue): Result<NewValue, Error>;
+        recoverCatching<NewValue>(transform: (error: Error) => NewValue): Result<NewValue, Error>;
     }
 }
 
@@ -35,11 +35,7 @@ Result.prototype.mapCatching = function (transform) {
     return Result.failure(this.rawValue as Error);
 };
 
-Result.prototype.recoverCatching = function <NewValue extends NonNullable<unknown>, Value extends NewValue>(
-    this: Result<Value, Error>,
-    transform: (error: Error) => NewValue,
-) {
-    const error = this.errorOrNull();
-    if (error == null) return this;
-    return runCatching(() => transform(error));
+Result.prototype.recoverCatching = function <NewValue, Value extends NewValue>(this: Result<Value, Error>, transform: (error: Error) => NewValue) {
+    if (this.isSuccess) return this;
+    return runCatching(() => transform(this.rawValue as Error));
 };

--- a/src/result.ts
+++ b/src/result.ts
@@ -171,7 +171,7 @@ export class Result<Value, ErrorValue = Error> {
      * @template Value
      * @template ErrorValue
      * @template NewErrorValue
-     * @param {function(ErrorValue): NewErrorValue} transform - A function that takes a value of type ErrorValue and returns a new value of type NewErrorValue.
+     * @param {(ErrorValue) => NewErrorValue} transform - A function that takes a value of type ErrorValue and returns a new value of type NewErrorValue.
      * @return {Result<Value, NewErrorValue>} The encapsulated result of the given transform function applied to the encapsulated value if this instance represents failure
      * or the original encapsulated value if it is success.
      */
@@ -237,11 +237,10 @@ export class Result<Value, ErrorValue = Error> {
      * failure or the original encapsulated value if it is success.
      */
     recover<NewValue, Value extends NewValue>(this: Result<Value, ErrorValue>, transform: (error: ErrorValue) => NewValue): Result<NewValue, ErrorValue> {
-        const error = this.errorOrNull();
-        if (error == null) {
+        if (this.isSuccess) {
             return this;
         }
-        return Result.success(transform(error));
+        return Result.success(transform(this.rawValue as ErrorValue));
     }
 
     /**

--- a/src/run-catching.ts
+++ b/src/run-catching.ts
@@ -9,7 +9,7 @@ import { Result } from './result';
  * @returns {Result<Value>} The encapsulated result if invocation was successful, catching any error that was thrown from the block function execution and
  * encapsulating it as a failure.
  */
-export const runCatching = <Value extends NonNullable<unknown>>(block: () => Value): Result<Value, Error> => {
+export const runCatching = <Value>(block: () => Value): Result<Value, Error> => {
     try {
         return Result.success(block());
     } catch (error) {


### PR DESCRIPTION
This commit removes overly restrictive `NonNullable` constraints on transformation methods for improved flexibility. Additionally, internal usage of `errorOrNull()` has been replaced with explicit `isSuccess` checks, ensuring accurate state evaluation even with `null` success values.